### PR TITLE
add a tcp echo test

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -44,6 +44,9 @@ uninstall:
 bin/%.bench: tests/%_bench.c $(INSTALLED_FILES)
 	$(CC) $< $(CFLAGS) -lchip -o $@
 
+bin/%: tests/%.c $(INSTALLED_FILES)
+	$(CC) $< $(CFLAGS) -lchip -o $@
+
 .PHONY: clean
 clean:
 	$(RM) -r *.a *.o *.gch *.test *.bench *.out *.dSYM bin/*

--- a/src/build
+++ b/src/build
@@ -33,7 +33,7 @@ if (test `{whatis musl-gcc}) {
     LIB_DIR = /usr/lib/musl/lib
 } else {
     INCLUDE_DIR = /usr/include
-    LIB_DIR = /usr/lib/
+    LIB_DIR = /usr/lib
 }
 
 cflags = -^$flags

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -22,6 +22,7 @@
 #include "runtime_epoll.h"
 #else
 #include "runtime_kqueue.h"
+#include <fcntl.h>
 #endif
 
 /* run-of-the-mill gcc grossness */

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -5,18 +5,18 @@
 #include <limits.h>
 
 /* 
-	For now, just linux and BSD,
-	and linux is easier to detect,
-	so just try to use kqueue if linux
-	isn't defined.
+   For now, just linux and BSD,
+   and linux is easier to detect,
+   so just try to use kqueue if linux
+   isn't defined.
 
-	The poller defines:
-	void poll(int ms);
-	void pollinit(void);
+   The poller defines:
+   void poll(int ms);
+   void pollinit(void);
 
-	And from runtime.h:
-	int ioctx_init(int fd, ioctx_t *ctx);
-	int ioctx_destroy(ioctx_t *ctx);
+   And from runtime.h:
+   int ioctx_init(int fd, ioctx_t *ctx);
+   int ioctx_destroy(ioctx_t *ctx);
 */
 #ifdef __linux__
 #include "runtime_epoll.h"
@@ -137,13 +137,13 @@ struct arena_s {
 };
 
 /*
-  mmap() a new arena.
+   mmap() a new arena.
 
-  The arena struct itself occupies the memory beyond
-  all of the stacks.
-  +------------------------------- ... ----------+
-  |  stack  |  stack  |  stack  |       arena    |
-  +------------------------------- ... ----------+
+   The arena struct itself occupies the memory beyond
+   all of the stacks.
+   +------------------------------- ... ----------+
+   |  stack  |  stack  |  stack  |      | arena   |
+   +------------------------------- ... ----------+
  */
 static arena_t *map_arena(void) {
 	void *mem = mmap(NULL, ARENA_MAPPING, PROT_READ|PROT_WRITE,
@@ -163,10 +163,10 @@ static arena_t *map_arena(void) {
 }
 
 /*
-  Rather than un-mapping the memory, we can tell the
-  kernel that the memory no longer needs to remain
-  valid (e.g. it can be unmapped and then zero-filled
-  if it is faulted back in.)
+   Rather than un-mapping the memory, we can tell the
+   kernel that the memory no longer needs to remain
+   valid (e.g. it can be unmapped and then zero-filled
+   if it is faulted back in.)
  */
 static void soft_offline_arena(arena_t *arena) {
 	void *top = arena;
@@ -174,10 +174,10 @@ static void soft_offline_arena(arena_t *arena) {
 	int flags;
 
 	/*
-	  MADV_FREE on BSD has more-or-less the same
-	  semantics as MADV_DONTNEED on linux (for 
-	  private anonymous mappings.) It's fine if the
-	  kernel zero-fills these pages.
+	   MADV_FREE on BSD has more-or-less the same
+	   semantics as MADV_DONTNEED on linux (for 
+	   private anonymous mappings.) It's fine if the
+	   kernel zero-fills these pages.
 	 */
 #ifdef MADV_FREE
 	flags = MADV_FREE;
@@ -234,9 +234,9 @@ static int arena_is_empty(arena_t *arena) {
 }
 
 /*
-  Each stack/task has a magic number that occupies
-  the top word. If we find a stack without this, then
-  a badly-behaved program clobbered it.
+   Each stack/task has a magic number that occupies
+   the top word. If we find a stack without this, then
+   a badly-behaved program clobbered it.
  */
 static inline uintptr_t stack_magic(task_t *task) {
 	return ((uintptr_t)task) ^ (((uintptr_t)task->stack)>>12);
@@ -528,6 +528,18 @@ static void io_unpark(task_t *task) {
 	ready(task);
 }
 
+/* schedule the target task *immediately* with i/o cancellation */
+static void io_cancel_now(task_t *task) {
+	runtime_assert_msg(task->status == STATUS_IOWAIT,
+			   "io cancelation of task not in iowait");
+
+	task->next = MAP_FAILED;
+	task->status = STATUS_RUNNABLE;
+	--runq.iowait;
+	ready(runq.running); /* set currently-running task as runnable */
+	swtch(task);
+}
+
 int wake(tasklist_t *tl) {
 	runtime_assert_msg(tl != &runq.queue,
 			  "wake called on worklist");
@@ -583,13 +595,6 @@ static void _sbrt_exit(void) {
 	run(target);
 }
 
-/*
-  Create a new runnable task.
-
-  (Usually this results in de-scheduling; allocators
-  of new tasks are put into a lower-priority queue
-  than other runnable tasks.)
- */
 void spawn(void (*start)(word_t), word_t data) {
 	task_t *t;
 	word_t stack;
@@ -613,13 +618,30 @@ void spawn(void (*start)(word_t), word_t data) {
 	return;
 }
 
-static void park_and_iowait(task_t **addr) {
+static int park_and_iowait(task_t **addr) {
 	*addr = runq.running;
 	runq.running->status = STATUS_IOWAIT;
 	++runq.iowait;
 	swtch(find_work(1));
 	*addr = NULL;
-	return;
+
+	/* async wakeup due to cancelation */
+	if (unlikely(runq.running->next == MAP_FAILED)) {
+		runq.running->next = NULL;
+		errno = ECANCELED;
+		return -1;
+	}
+
+	return 0;
+}
+
+void ioctx_cancel(ioctx_t *ctx) {
+	if (ctx->writer)
+		io_cancel_now(ctx->writer);
+	
+	if (ctx->reader)
+		io_cancel_now(ctx->reader);
+	
 }
 
 int ioctx_accept(ioctx_t *ctx, struct sockaddr *addr, socklen_t *addrlen) {
@@ -644,13 +666,21 @@ try:
 }
 
 ssize_t ioctx_write(ioctx_t *ctx, char *buf, size_t bytes) {
+	if (unlikely(ctx->fd == -1)) {
+		errno = ECANCELED;
+		return -1;
+	}
 	ssize_t amt;
 try:
 	amt = write(ctx->fd, buf, bytes);
 	if ((amt == -1) && (errno == EAGAIN)) {
 		runtime_assert_msg(ctx->writer == NULL,
 				   "multiple writers on an ioctx");
-		park_and_iowait(&ctx->writer);
+
+		if (park_and_iowait(&ctx->writer) < 0) {
+			return -1;
+		}
+		
 		goto try;
 	}
 	return amt;
@@ -663,7 +693,10 @@ try:
 	if ((amt == -1) && (errno == EAGAIN)) {
 		runtime_assert_msg(ctx->reader == NULL,
 				   "multiple readers on an ioctx");
-		park_and_iowait(&ctx->reader);
+
+		if (park_and_iowait(&ctx->reader) < 0)
+			return -1;
+		
 		goto try;
 	}
 	return amt;

--- a/src/runtime_epoll.h
+++ b/src/runtime_epoll.h
@@ -34,7 +34,14 @@ int ioctx_destroy(ioctx_t *ctx) {
 	if (epoll_ctl(epfd, EPOLL_CTL_DEL, ctx->fd, NULL) < 0) 
 		return -1;
 	
-	return close(ctx->fd);
+	if (close(ctx->fd) == -1)
+		return -1;
+
+	ctx->fd = -1;
+	
+	/* don't leak tasks parked on this ioctx */
+	ioctx_cancel(ctx);
+	return 0;
 }
 
 static void poll(int ms) {

--- a/src/runtime_kqueue.h
+++ b/src/runtime_kqueue.h
@@ -45,7 +45,12 @@ int ioctx_init(int fd, ioctx_t *ctx) {
 }
 
 int ioctx_destroy(ioctx_t *ctx) {
-	return close(ctx->fd);
+	if (close(ctx->fd) == -1)
+		return -1;
+
+	ctx->fd = -1;
+	ioctx_cancel(ctx);
+	return 0;
 }
 
 static void poll(int ms) {

--- a/src/tests/basic_test.c
+++ b/src/tests/basic_test.c
@@ -12,7 +12,7 @@
 static int count;
 static sema_t sema;
 
-static void inc(void *data) {
+static void inc(word_t data) {
 	if (++count == INCS) {
 		tsk_stats_t stats;
 		get_tsk_stats(&stats);
@@ -41,10 +41,12 @@ int main(void) {
 	
 	/* no tasks to run -- should return immediately */
 	sched();
-	
+
+	word_t zero;
+	zero.val = 0;
 	/* spawn tasks that run 'inc' */
 	for (int i=0; i<INCS; ++i) {
-		spawn(inc, NULL);
+		spawn(inc, zero);
 	}
 	get_tsk_stats(&stats);
 	printf("after %d spawns, %d parked, %d free, %d runnable\n", INCS, stats.parked, stats.free, stats.runnable);

--- a/src/tests/cancel_test.c
+++ b/src/tests/cancel_test.c
@@ -1,0 +1,127 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <assert.h>
+#include "../chip.h"
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+static sema_t rdsema;
+
+static char write_buf[4096];
+
+static char read_buf[4096];
+
+#define please(expr) if ((expr) == -1) { perror(#expr); _exit(1); }
+
+#define NUM_BYTES (1<<22)
+
+void pipe_canceler(word_t data) {
+	ioctx_t *ctx = data.ptr;
+	ioctx_cancel(ctx);
+}
+
+void pipe_writer(word_t data) {
+	int fd = data.fd;
+	ioctx_t ctx;
+	tsk_stats_t stats;
+	ssize_t amt = 0;
+	ssize_t this;
+	ssize_t w;
+	int zero;
+
+	please(ioctx_init(fd, &ctx));
+	please(zero = open("/dev/zero", O_RDONLY));
+
+	/* as soon as we block, the cancel-er will be spawned */
+	word_t out;
+	out.ptr = &ctx;
+	spawn(pipe_canceler, out);
+	
+	do {
+		please(this = read(zero, write_buf, 4096));
+		get_tsk_stats(&stats);
+	        w = ioctx_write(&ctx, write_buf, this);
+		if (w == -1) {
+			if (errno == ECANCELED) {
+				puts("write got ECANCELED");
+				continue;
+			} else {
+				perror("write"); _exit(1);
+			}
+		}
+		amt += w;
+	} while (amt < NUM_BYTES);
+
+
+	please(ioctx_destroy(&ctx));
+	puts("write ok.");
+	return;
+}
+
+void pipe_reader(word_t data) {
+	int fd = data.fd;
+	ioctx_t ctx;
+	tsk_stats_t stats;
+	ssize_t this;
+	ssize_t amt = 0;
+
+	please(ioctx_init(fd, &ctx));
+	
+	word_t out;
+	out.ptr = &ctx;
+	spawn(pipe_canceler, out);
+
+	
+	for (;;) {
+		/* have the runtime perform a sanity check */
+		get_tsk_stats(&stats);
+	rd:
+		this = ioctx_read(&ctx, read_buf, 4096);
+		switch (this) {
+		case 0:
+			goto done;
+		case -1:
+			if (errno == ECANCELED) {
+				puts("read got ECANCELED");
+				goto rd;
+			} else {
+				perror("read"); _exit(1);
+			}
+		default:
+			amt += this;
+			break;
+		}
+	}
+done:
+	assert(amt == NUM_BYTES);
+	please(ioctx_destroy(&ctx));
+	puts("read ok.");
+	post(&rdsema);
+	return;
+}
+
+int main(void) {
+	puts("running pipe cancelation tests...");
+
+	int pipefd[2];
+#ifdef __gnu_linux__
+	please(pipe2(pipefd, O_NONBLOCK|O_CLOEXEC));
+#else
+	please(pipe(pipefd));
+	fcntl(pipefd[0], F_SETFL, O_NONBLOCK|(fcntl(pipefd[0], F_GETFL)));
+	fcntl(pipefd[1], F_SETFL, O_NONBLOCK|(fcntl(pipefd[1], F_GETFL)));
+#endif
+
+	word_t wfd;
+	wfd.fd = pipefd[1];
+	spawn(pipe_writer, wfd);
+	
+	word_t rfd;
+	rfd.fd = pipefd[0];
+	spawn(pipe_reader, rfd);
+
+	park(&rdsema); /* wait for reads to complete */
+	puts(__FILE__ " passed.");
+	return 0;
+}

--- a/src/tests/echo.c
+++ b/src/tests/echo.c
@@ -1,10 +1,13 @@
-#include "chip/chip.h"
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#ifndef __linux__
+#include <fcntl.h>
+#endif
+#include "chip/chip.h"
 
 #define please(expr) if ((expr) == -1) { perror(#expr); _exit(1); }
 
@@ -52,7 +55,13 @@ int main(void) {
 	ioctx_t lctx;
 	struct sockaddr addr;
 	socklen_t addrlen;
+
+#ifdef __linux__
 	please(lfd = socket(AF_INET, SOCK_STREAM|SOCK_NONBLOCK|SOCK_CLOEXEC, 0));
+#else
+	please(lfd = socket(AF_INET, SOCK_STREAM, 0));
+	fcntl(lfd, F_SETFL, O_NONBLOCK|O_CLOEXEC|fcntl(lfd, F_GETFL));
+#endif
 
 	struct sockaddr_in laddr;
 	memset(&laddr, 0, sizeof(laddr));

--- a/src/tests/echo.c
+++ b/src/tests/echo.c
@@ -1,0 +1,73 @@
+#include "chip/chip.h"
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#define please(expr) if ((expr) == -1) { perror(#expr); _exit(1); }
+
+/* we have 12kB stacks, so this should fit fine. */
+#define STACK_BUF_SIZE 8192
+
+void echo(word_t arg0) {
+	ioctx_t ctx;
+	char buf[STACK_BUF_SIZE];
+
+	please(ioctx_init(arg0.fd, &ctx));
+
+	for (;;) {
+		ssize_t ret;
+		ssize_t res = ioctx_read(&ctx, buf, STACK_BUF_SIZE);
+		switch (res) {
+		case -1:
+			perror("read");
+		case 0:
+			goto done;
+		default:
+			ret = 0;
+			while (ret < res) {
+				ssize_t w = ioctx_write(&ctx, buf + ret, res - ret);
+				switch (w) {
+				case -1:
+					perror("write");
+				case 0:
+					goto done;
+				default:
+					ret += w;
+				}
+			}
+		}
+	}
+
+done:
+	please(ioctx_destroy(&ctx));
+}
+
+#define PORT 7070
+
+int main(void) {
+	int lfd;
+	ioctx_t lctx;
+	struct sockaddr addr;
+	socklen_t addrlen;
+	please(lfd = socket(AF_INET, SOCK_STREAM|SOCK_NONBLOCK|SOCK_CLOEXEC, 0));
+
+	struct sockaddr_in laddr;
+	memset(&laddr, 0, sizeof(laddr));
+	laddr.sin_family = AF_INET;
+	laddr.sin_port = htons(PORT);
+	laddr.sin_addr.s_addr = INADDR_ANY;
+
+	please(bind(lfd, (const struct sockaddr *)&laddr, sizeof(laddr)));
+	please(ioctx_init(lfd, &lctx));
+
+	please(listen(lfd, 128));
+	printf("listening on :%d...\n", PORT);
+	for (;;) {
+		word_t arg;
+		please(arg.fd = ioctx_accept(&lctx, &addr, &addrlen));
+		spawn(echo, arg);
+	}
+}

--- a/src/tests/many_test.c
+++ b/src/tests/many_test.c
@@ -16,7 +16,7 @@ static int count;
 static sema_t sema;   /* 'done' semaphore */
 static mutex_t ilock; /* lock to force many tasks to exist */
 
-static void inc(void *data) {
+static void inc(word_t data) {
 	lock(&ilock);
 	if (++count == INCS) {
 		post(&sema);
@@ -28,13 +28,15 @@ static void inc(void *data) {
 int main(void) {
 	puts("running "__FILE__);
 	lock(&ilock);
-
+	word_t zero;
+	zero.val = 0;
+	
         /* 
 	   with the lock held, start a bunch of tasks 
 	   that contend on the lock.
 	 */
 	for (int i=0; i<INCS; ++i) {
-		spawn(inc, NULL);
+		spawn(inc, zero);
 	}
 
 	tsk_stats_t stats;

--- a/src/tests/pingpong_bench.c
+++ b/src/tests/pingpong_bench.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include "chip/chip.h"
 
-void pong(void* nothing) {
+void pong(word_t arg) {
 	for (;;) {
 		sched();
 	}
@@ -13,7 +13,9 @@ void pong(void* nothing) {
 int main(void) {
 	puts("starting ping-pong test...");
 
-	spawn(pong, NULL);
+	word_t arg;
+	arg.val = 0;
+	spawn(pong, arg);
 	clock_t start = clock();
 	for (int i=0; i<PONGS; ++i) {
 		sched();

--- a/src/tests/pipe_test.c
+++ b/src/tests/pipe_test.c
@@ -16,10 +16,10 @@ static char read_buf[4096];
 
 #define NUM_BYTES (1<<22)
 
-void pipe_writer(void *data) {
+void pipe_writer(word_t data) {
 	ioctx_t ctx;
 	tsk_stats_t stats;
-	int wfd = ((int *)data)[1];
+	int wfd = ((int *)data.ptr)[1];
 	ssize_t amt = 0;
 	ssize_t this;
 	ssize_t w;
@@ -40,12 +40,12 @@ void pipe_writer(void *data) {
 	return;
 }
 
-void pipe_reader(void *data) {
+void pipe_reader(word_t data) {
 	ioctx_t ctx;
 	tsk_stats_t stats;
 	ssize_t this;
 	ssize_t amt = 0;
-	int rfd = ((int *)data)[0];
+	int rfd = ((int *)data.ptr)[0];
 	
 	please(ioctx_init(rfd, &ctx));
 	
@@ -70,6 +70,8 @@ int main(void) {
 	puts("running pipe tests...");
 
 	int pipefd[2];
+	word_t arg0;
+	arg0.ptr = pipefd;
 #ifdef __gnu_linux__
 	please(pipe2(pipefd, O_NONBLOCK|O_CLOEXEC));
 #else
@@ -78,8 +80,8 @@ int main(void) {
 	fcntl(pipefd[1], F_SETFL, O_NONBLOCK|(fcntl(pipefd[1], F_GETFL)));
 #endif
 
-	spawn(pipe_writer, pipefd);
-	spawn(pipe_reader, pipefd);
+	spawn(pipe_writer, arg0);
+	spawn(pipe_reader, arg0);
 
 	park(&rdsema); /* wait for reads to complete */
 	puts(__FILE__ " passed.");

--- a/src/tests/sequential_bench.c
+++ b/src/tests/sequential_bench.c
@@ -13,7 +13,7 @@
 static int count;
 static sema_t sema;
 
-static void inc(void *data) {
+static void inc(word_t ignored) {
 	if (++count == INCS) {
 		post(&sema);
 	}
@@ -25,8 +25,10 @@ int main(void) {
 	
 	/* spawn tasks that run 'inc' */
 	clock_t t = clock();
+	word_t zero;
+	zero.ptr = NULL;
 	for (int i=0; i<INCS; ++i) {
-		spawn(inc, NULL);
+		spawn(inc, zero);
 	}
 	park(&sema);
 	t = clock() - t;


### PR DESCRIPTION
 - Add a TCP echo test in tests/echo.c
 - Add `ioctx_accept()` to the runtime (which does precisely what you think it does)
 - Add `ioctx_cancel()` to the runtime, which allows tasks to unblock other tasks parked 
   in i/o with errno set to ECANCELED.
 - Make `ioctx_destroy()` imply `ioctx_cancel()`, which prevents possible races in which 
   tasks could be leaked by blocking on file descriptors that have been closed and removed 
   from the poll set.
 - Fix a bug in `swtch()` that assumed a task
   would never schedule itself. (This can and
   does happen in real life.)
 - Change the argument to spawn'd tasks to be a union so that an `int` can be passed as an argument in a standards-compliant way.

Using just one core of my i7-5960K, I get 200,000 requests/sec
out of 128 clients sending 4kB of data. (For comparison, the go
code that drives the client eats 300% CPU.)
